### PR TITLE
Fix CoW report errors on Swap Card

### DIFF
--- a/src/components/AdvancedSettingsAlert.tsx
+++ b/src/components/AdvancedSettingsAlert.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useAdvancedSettingsStore } from "#/hooks/useAdvancedSettings";
+import {
+  defaultAdvancedSettings,
+  haveSettingsChanged,
+  useAdvancedSettingsStore,
+} from "#/hooks/useAdvancedSettings";
 
 import { AlertCard } from "./ui/alert-card";
 
@@ -9,12 +13,10 @@ export function AdvancedSettingsAlert() {
     (state) => state.advancedSettings,
   );
 
-  const isAdvancedSettingsChanged =
-    advancedSettings?.receiver.toLowerCase() !== "" ||
-    advancedSettings?.maxHoursSinceOracleUpdates !== 1 ||
-    advancedSettings?.tokenBuyOracle ||
-    advancedSettings?.tokenBuyOracle ||
-    advancedSettings?.partiallyFillable;
+  const isAdvancedSettingsChanged = haveSettingsChanged(
+    advancedSettings,
+    defaultAdvancedSettings,
+  );
 
   if (!isAdvancedSettingsChanged) return null;
 

--- a/src/components/AdvancedSettingsDialog.tsx
+++ b/src/components/AdvancedSettingsDialog.tsx
@@ -17,7 +17,11 @@ import cn from "clsx";
 import * as React from "react";
 import { useForm, useWatch } from "react-hook-form";
 
-import { useAdvancedSettingsStore } from "#/hooks/useAdvancedSettings";
+import {
+  defaultAdvancedSettings,
+  haveSettingsChanged,
+  useAdvancedSettingsStore,
+} from "#/hooks/useAdvancedSettings";
 import { useSafeApp } from "#/hooks/useSafeApp";
 import { ChainId } from "#/lib/publicClients";
 import { generateAdvancedSettingsSchema } from "#/lib/schema";
@@ -35,30 +39,12 @@ import { Checkbox } from "./ui/checkbox";
 import { Form } from "./ui/form";
 import { Input } from "./ui/input";
 
-function haveSettingsChanged(
-  current: Partial<AdvancedSwapSettings>,
-  defaults: AdvancedSwapSettings,
-): boolean {
-  return Object.keys(current).some(
-    (key) =>
-      current[key as keyof AdvancedSwapSettings] !==
-      defaults[key as keyof AdvancedSwapSettings],
-  );
-}
-
 export function AdvancedSettingsDialog() {
   const [open, setOpen] = React.useState(false);
-  const { safeAddress, chainId } = useSafeApp();
+  const { chainId } = useSafeApp();
   const [advancedSettings, setAdvancedSettings] = useAdvancedSettingsStore(
     (state) => [state.advancedSettings, state.setAdvancedSettings],
   );
-  const defaultSettings = {
-    receiver: safeAddress,
-    maxHoursSinceOracleUpdates: 1,
-    tokenBuyOracle: "" as const,
-    tokenSellOracle: "" as const,
-    partiallyFillable: false,
-  } as const;
 
   const form = useForm<AdvancedSwapSettings>({
     resolver: zodResolver(generateAdvancedSettingsSchema(chainId as ChainId)),
@@ -74,7 +60,7 @@ export function AdvancedSettingsDialog() {
   const currentValues = useWatch({ control });
   const areSettingsDifferentFromDefault = haveSettingsChanged(
     currentValues,
-    defaultSettings,
+    defaultAdvancedSettings,
   );
 
   const receiver = useWatch({ control, name: "receiver" });
@@ -207,8 +193,8 @@ export function AdvancedSettingsDialog() {
                 type="button"
                 className="text-xs flex gap-1 text-white items-center pb-0 h-min"
                 onClick={() => {
-                  reset(defaultSettings);
-                  setAdvancedSettings(defaultSettings);
+                  reset(defaultAdvancedSettings);
+                  setAdvancedSettings(defaultAdvancedSettings);
                 }}
               >
                 <ResetIcon className="size-3" /> Reset to default settings

--- a/src/components/TokenInputCard.tsx
+++ b/src/components/TokenInputCard.tsx
@@ -59,15 +59,6 @@ function TokenInputCardComponent({ side }: { side: "Sell" | "Buy" }) {
     state.setTokenSellBalance,
   ]);
   const updateOracle = useOracleStore((state) => state.updateOracle);
-  // const { data: tokenSellBalance } = useBalance({
-  //   address: safeAddress,
-  //   token: currentDraftOrder?.tokenSell.address,
-  // });
-  // const { data: tokenBuyBalance } = useBalance({
-  //   address: safeAddress,
-  //   token: currentDraftOrder?.tokenBuy.address,
-  // });
-
   const tokenBalance = side === "Buy" ? tokenBuyBalance : tokenSellBalance;
   const setTokenBalance =
     side === "Buy" ? setTokenBuyBalance : setTokenSellBalance;
@@ -149,24 +140,21 @@ function TokenInputCardComponent({ side }: { side: "Sell" | "Buy" }) {
                   0.0001,
                 )}{" "}
               </span>
-              {!isAmountDisabled &&
-                tokenBalance &&
-                tokenBalance !== "0" &&
-                amount.toString().includes(formatNumber(tokenBalance)) && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="py-0 px-1 h-fit text-accent text-xs"
-                    onClick={() => {
-                      setValue(
-                        amountFieldName,
-                        Number(convertStringToNumberAndRoundDown(tokenBalance)),
-                      );
-                    }}
-                  >
-                    Max
-                  </Button>
-                )}
+              {!isAmountDisabled && tokenBalance && tokenBalance !== "0" && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="py-0 px-1 h-fit text-accent text-xs"
+                  onClick={() => {
+                    setValue(
+                      amountFieldName,
+                      Number(convertStringToNumberAndRoundDown(tokenBalance)),
+                    );
+                  }}
+                >
+                  Max
+                </Button>
+              )}
             </span>
           )}
         </div>

--- a/src/components/swap-card/SwapForm.tsx
+++ b/src/components/swap-card/SwapForm.tsx
@@ -7,8 +7,7 @@ import { useForm } from "react-hook-form";
 
 import { useDraftOrder } from "#/hooks/useDraftOrder";
 import { useSafeApp } from "#/hooks/useSafeApp";
-import { ChainId } from "#/lib/publicClients";
-import { generateSwapSchema } from "#/lib/schema";
+import { swapSchema } from "#/lib/schema";
 import { SwapData } from "#/lib/types";
 
 import { AdvancedSettingsAlert } from "../AdvancedSettingsAlert";
@@ -25,11 +24,6 @@ import { SwapCardSubmitButton } from "./SwapCardSubmitButton";
 export function SwapForm() {
   const { chainId, safeAddress } = useSafeApp();
 
-  const formSchema = React.useMemo(
-    () => generateSwapSchema(chainId as ChainId),
-    [chainId],
-  );
-
   const [currentDraftOrder, setCurrentDraftOrder, createDraftOrder] =
     useDraftOrder((state) => [
       state.currentDraftOrder,
@@ -38,7 +32,7 @@ export function SwapForm() {
     ]);
 
   const form = useForm<SwapData>({
-    resolver: zodResolver(formSchema),
+    resolver: zodResolver(swapSchema),
     defaultValues: {
       isSellOrder: true,
     },

--- a/src/hooks/useAdvancedSettings.ts
+++ b/src/hooks/useAdvancedSettings.ts
@@ -8,13 +8,24 @@ interface AdvancedSettingsState {
   setAdvancedSettings: (settings: AdvancedSwapSettings) => void;
 }
 
-const defaultAdvancedSettings: AdvancedSwapSettings = {
+export const defaultAdvancedSettings: AdvancedSwapSettings = {
   receiver: "",
   maxHoursSinceOracleUpdates: 1,
   tokenBuyOracle: "",
   tokenSellOracle: "",
   partiallyFillable: false,
 };
+
+export function haveSettingsChanged(
+  current: Partial<AdvancedSwapSettings>,
+  defaults: AdvancedSwapSettings,
+): boolean {
+  return Object.keys(current).some(
+    (key) =>
+      current[key as keyof AdvancedSwapSettings] !==
+      defaults[key as keyof AdvancedSwapSettings],
+  );
+}
 
 export const useAdvancedSettingsStore = create<AdvancedSettingsState>()(
   persist(

--- a/src/lib/calculateAmounts.ts
+++ b/src/lib/calculateAmounts.ts
@@ -15,7 +15,7 @@ export function calculateSellAmount({
   amount: number;
   limitPrice: number;
 }): number {
-  return isSellOrder ? amount : amount * limitPrice;
+  return isSellOrder ? amount : amount / limitPrice;
 }
 
 export function calculateBuyAmount({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
 import { Address } from "viem";
-import { generateAdvancedSettingsSchema, generateSwapSchema } from "./schema";
+import { generateAdvancedSettingsSchema, swapSchema } from "./schema";
 import { z } from "zod";
 import { UserStopLossOrdersQuery } from "./gql/composable-cow/__generated__/1";
 import { ArrElement, GetDeepProp } from "@bleu/ui";
@@ -21,7 +21,7 @@ export interface ITokenWithValue extends IToken {
 export type AdvancedSwapSettings = z.input<
   ReturnType<typeof generateAdvancedSettingsSchema>
 >;
-export type SwapData = z.input<ReturnType<typeof generateSwapSchema>>;
+export type SwapData = z.input<typeof swapSchema>;
 
 export type DraftOrder = SwapData &
   AdvancedSwapSettings & {


### PR DESCRIPTION
Fix:

- "I've reset to default my settings and saved changes, but Advanced mode message is still displayed"
- "Buy orders calculation is wrong: 5 USDC cannot be sold for 2000 WETH. 5 USDC should be sold for 0.13 WETH (need to 5/392 instead of 5*392)"


Also this PR:
- Remove unucessary quote validation to validate order. This was being used to validate that the liquidity is enough to be traded on CoW. However, stop loss orders will execute in a different state so we can't be sure of that.
- Fix bug on `Max` button not showing on token card